### PR TITLE
Update GitHub Actions to requested versions

### DIFF
--- a/.github/workflows/isa-build.yml
+++ b/.github/workflows/isa-build.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
     # Checkout the repository
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -49,7 +49,7 @@ jobs:
     # Upload the riscv-privileged PDF file
       - name: Upload riscv-privileged.pdf
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: riscv-privileged-${{ env.SHORT_SHA }}.pdf
           path: ${{ github.workspace }}/build/riscv-privileged.pdf
@@ -58,7 +58,7 @@ jobs:
     # Upload the riscv-privileged HTML file
       - name: Upload riscv-privileged.html
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: riscv-privileged-${{ env.SHORT_SHA }}.html
           path: ${{ github.workspace }}/build/riscv-privileged.html
@@ -67,7 +67,7 @@ jobs:
     # Upload the riscv-privileged EPUB file
       - name: Upload riscv-privileged.epub
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: riscv-privileged-${{ env.SHORT_SHA }}.epub
           path: ${{ github.workspace }}/build/riscv-privileged.epub
@@ -76,7 +76,7 @@ jobs:
     # Upload the riscv-unprivileged PDF file
       - name: Upload riscv-unprivileged.pdf
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: riscv-unprivileged-${{ env.SHORT_SHA }}.pdf
           path: ${{ github.workspace }}/build/riscv-unprivileged.pdf
@@ -85,7 +85,7 @@ jobs:
     # Upload the riscv-unprivileged HTML file
       - name: Upload riscv-unprivileged.html
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: riscv-unprivileged-${{ env.SHORT_SHA }}.html
           path: ${{ github.workspace }}/build/riscv-unprivileged.html
@@ -94,7 +94,7 @@ jobs:
     # Upload the riscv-unprivileged EPUB file
       - name: Upload riscv-unprivileged.epub
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: riscv-unprivileged-${{ env.SHORT_SHA }}.epub
           path: ${{ github.workspace }}/build/riscv-unprivileged.epub
@@ -103,7 +103,7 @@ jobs:
       - name: Create Release
         if: steps.build_files.outcome == 'success' && github.event_name == 'workflow_dispatch' && github.event.inputs.create_release == 'true'
         #uses: softprops/action-gh-release@v2.2.2
-        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090
+        uses: softprops/action-gh-release@v2
         with:
           draft: false
           tag_name: riscv-isa-release-${{ env.SHORT_SHA }}-${{ env.CURRENT_DATE }}

--- a/.github/workflows/merge-and-release.yml
+++ b/.github/workflows/merge-and-release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -34,7 +34,7 @@ jobs:
     # Upload the riscv-privileged PDF file
       - name: Upload riscv-privileged.pdf
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: riscv-privileged-${{ env.SHORT_SHA }}.pdf
           path: ${{ github.workspace }}/build/riscv-privileged.pdf
@@ -42,7 +42,7 @@ jobs:
     # Upload the riscv-privileged HTML file
       - name: Upload riscv-privileged.html
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: riscv-privileged-${{ env.SHORT_SHA }}.html
           path: ${{ github.workspace }}/build/riscv-privileged.html
@@ -50,7 +50,7 @@ jobs:
     # Upload the riscv-privileged EPUB file
       - name: Upload riscv-privileged.epub
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: riscv-privileged-${{ env.SHORT_SHA }}.epub
           path: ${{ github.workspace }}/build/riscv-privileged.epub
@@ -58,7 +58,7 @@ jobs:
     # Upload the riscv-unprivileged PDF file
       - name: Upload riscv-unprivileged.pdf
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: riscv-unprivileged-${{ env.SHORT_SHA }}.pdf
           path: ${{ github.workspace }}/build/riscv-unprivileged.pdf
@@ -66,7 +66,7 @@ jobs:
     # Upload the riscv-unprivileged HTML file
       - name: Upload riscv-unprivileged.html
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: riscv-unprivileged-${{ env.SHORT_SHA }}.html
           path: ${{ github.workspace }}/build/riscv-unprivileged.html
@@ -74,13 +74,13 @@ jobs:
     # Upload the riscv-unprivileged EPUB file
       - name: Upload riscv-unprivileged.epub
         if: steps.build_files.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: riscv-unprivileged-${{ env.SHORT_SHA }}.epub
           path: ${{ github.workspace }}/build/riscv-unprivileged.epub
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2.4.1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GHTOKEN }}
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
       - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
This updates GitHub Actions workflow references to the requested versions.

Targets:
- `actions/checkout` -> `v6`
- `actions/upload-artifact` -> `v6`
- `softprops/action-gh-release` -> `v2`
